### PR TITLE
Add wrapping for forms with lots of candidates

### DIFF
--- a/src/components/CandidateBox.js
+++ b/src/components/CandidateBox.js
@@ -66,6 +66,7 @@ export const CandidateBox = ({ candBox, candidates, tightLayout, onlyDisplay }) 
           padding:0,
           margin:0,
           minHeight: "40px",
+          flexWrap: "wrap",
         }}
       >
         <SortableContext 


### PR DESCRIPTION
## Description

I noticed the candidates would go off screen when there were too many options or if the name was too long. With this change they'll wrap😊.

## Before

<img width="1366" height="508" alt="image" src="https://github.com/user-attachments/assets/baf56b73-bc9b-4ab8-ac07-4f9889dd3c63" />


## After
<img width="1225" height="531" alt="image" src="https://github.com/user-attachments/assets/976adb2c-914b-4552-9462-f4971f730687" />

